### PR TITLE
Update railties version for rails 5

### DIFF
--- a/purecss-rails.gemspec
+++ b/purecss-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("railties", ">= 3.2.6", "< 5")
+  spec.add_dependency("railties", ">= 3.2.6", "< 6")
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Hi, I am trying to upgrade my rails version from 4.2 to 5.0.
However `railties` version is conflicted:

```
Bundler could not find compatible versions for gem "railties":
  In snapshot (Gemfile.lock):
    railties (= 5.0.1)
...

purecss-rails was resolved to 0.0.1, which depends on
      railties (< 5, >= 3.2.6)
```

I tried to use this libraries with rails 5. It works fine, as far as I see it.
Please use this pull request as a reference.
Thank you.